### PR TITLE
Fix svelte tutorial for case sensitive OS

### DIFF
--- a/svelte-tutorial/app/pages/Details.svelte
+++ b/svelte-tutorial/app/pages/Details.svelte
@@ -30,8 +30,8 @@
 
   <script>
     import { navigate } from 'svelte-native'
-	import { FlickService } from '../services/FlickService';
-    
+	import { FlickService } from '../services/flickService';
+
     export let flickId;
     let flick = FlickService.getInstance().getFlickById(flickId);
 </script>

--- a/svelte-tutorial/app/pages/Home.svelte
+++ b/svelte-tutorial/app/pages/Home.svelte
@@ -44,7 +44,7 @@
     import { navigate } from 'svelte-native'
 	import { Template } from 'svelte-native/components'
     import Details from './Details.svelte';
-	import { FlickService } from '../services/FlickService';
+	import { FlickService } from '../services/flickService';
 
     let flicks = FlickService.getInstance().getFlicks();
 


### PR DESCRIPTION
The svelte-tutorial can not be built running Linux because the FlickService is imported from file FlickService instead of flickService.

This PR fixes it.